### PR TITLE
Add PrettyPrint, Bookmarks, URLEncoding

### DIFF
--- a/brocli/ac-urls.js
+++ b/brocli/ac-urls.js
@@ -37,6 +37,8 @@ var settingsPage = {
     'catalog': '/Settings/Catalog/General.aspx',
     'cat': '/Settings/Catalog/General.aspx',
     'content': '/Settings/Content/General.aspx?',
+    'domain': '/account/domaincontrol.aspx',
+    'dc': '/account/domaincontrol.aspx',
     'marketing': '/Settings/Marketing/General.aspx',
     'microstores': '/Settings/Microstores/General.aspx',
     'orders': '/Settings/Orders/General.aspx',

--- a/brocli/background.js
+++ b/brocli/background.js
@@ -33,7 +33,7 @@ chrome.omnibox.onInputChanged.addListener(function (text, suggest) {
     var query = {currentWindow: true, active: true};
     var splitText = text.split(" ");
     sugParser.parse(splitText);
-    chrome.omnibox.setDefaultSuggestion({description:'[site] (-pagetype) [id|entity]'});
+    chrome.omnibox.setDefaultSuggestion({description:'Welcome to brocli -- the browser commandline interface.'});
     sugs.forEach(function(sug) {
         suggestions.push({content: sug, description: sug})
     });

--- a/brocli/commands.js
+++ b/brocli/commands.js
@@ -34,37 +34,7 @@ var acSwitches = [
 var acParser = new optparse.OptionParser(acSwitches);
 
 acParser.on(0, function (value) {
-    if (isUrl(value)) {function isZD (url) {
-        var zdRe = new RegExp('.zendesk.com');
-        return zdRe.test(url);
-    }
-    
-    function isTicket (url) {
-        var ticketRe = new RegExp('/agent/tickets/');
-        return ticketRe.test(url);
-    }
-    
-    function goToFromZD() {
-        var split = currentLocation.split('/agent/tickets/');
-        var ticketID = split[split.length-1];
-        var url = zdDomain.concat('/api/v2/tickets/', ticketID);
-        getJson(url, function (data) {
-            var fields = {};
-            data.ticket.fields.forEach(function(i) {
-                fields[i.id] = i.value;
-            });
-            var site = fields[21662133];
-            if (isUrl(site)) {
-            options.domain = site;
-            }else if (isUrl('https://'.concat(site))) {
-                options.domain = 'https://'.concat(site);
-            }
-            var domainPresent = options.domain || "";
-            goToMany(domainPresent, options.paths);
-            resetOptions();
-        });
-    }
-    
+    if (isUrl(value)) {
       options.domain = value;
     }else if (isUrl('https://'.concat(value))) {
         var cmdUrl = new URL(chrome.runtime.getURL('/_generated_background_page.html'));
@@ -130,12 +100,11 @@ function goToFromZD() {
         var site = fields[21662133];
         if (isUrl(site)) {
         options.domain = site;
-        }else if (isUrl('https://'.concat(site))) {
-            options.domain = 'https://'.concat(site);
+        }else if (isUrl('http://'.concat(site))) {
+            options.domain = 'http://'.concat(site);
         }
         var domainPresent = options.domain || "";
         goToMany(domainPresent, options.paths);
-        resetOptions();
     });
 }
 
@@ -155,6 +124,7 @@ function resetOptions () {
     options.newTab = false;
     options.paths = [];
     options.action = undefined;
+    options.domain = undefined;
 }
 
 var Executer = Executer();
@@ -167,7 +137,6 @@ function runAcCommands (commands) {
     } else {
         var domainPresent = options.domain || "";
         goToMany(domainPresent, options.paths);
-        resetOptions();
     }
 }
 

--- a/brocli/commands.js
+++ b/brocli/commands.js
@@ -2,6 +2,8 @@
  * @fileOverview Uses optparse.js to parse command switches
  */
 
+var extensionId = chrome.runtime.id;
+
 var options = {
     action: undefined,
     domain: undefined,
@@ -50,11 +52,16 @@ acParser.on('*', function (name, value) {
     options.paths.extend(buildAcPaths(name, value));
 });
 
-//General Web Switches and Parser
+/**
+* General Web Switches and Parser
+*/
 var webSwitches = [
     ['-t','--new-tab', 'open in new tab'],
     ['-k', '--keyboard-shortcuts', 'view and configure all extension keyboard shortcusts'],
-    ['-cs', '--custom-searches', 'configure chrome customer searches']
+    ['-cs', '--custom-searches', 'configure chrome customer searches'],
+    ['-pp', '--pretty-print [STRING]', 'pretty print a string of code'],
+    ['-url', '--url-encode [STRING]', 'url encode a string'],
+    ['-com', '--command [BOOKMARK]', 'url encode a string']
 ]
 
 var webParser = new optparse.OptionParser(webSwitches);
@@ -69,6 +76,28 @@ webParser.on('*', function (name) {
 webParser.on('keyboard-shortcuts', function (name) {
     options.newTab = true;
     options.paths.push('chrome://extensions/configureCommands');
+});
+
+webParser.on('pretty-print', function (name, value) {
+    chrome.storage.local.set({'output': formatXml(value)}, function() {
+        window.open("chrome-extension://"+ extensionId +"/output.html");
+    });
+});
+
+webParser.on('url-encode', function (name, value) {
+    chrome.storage.local.set({'output': encodeURIComponent(value)}, function() {
+        window.open("chrome-extension://"+ extensionId +"/output.html");
+    });
+});
+
+webParser.on('command', function (name, value) {
+    chrome.bookmarks.search(value, function(results){
+        console.log(results);
+        results.forEach(function(res){
+            if (res.title == value)
+                window.open(res.url);         
+        });
+    });
 });
 
 var sugs = [];
@@ -130,6 +159,7 @@ function resetOptions () {
 var Executer = Executer();
 
 function runAcCommands (commands) {
+    options.entered = false;
     acParser.parse(commands);
     webParser.parse(commands);
     if (isZD(currentLocation) && isTicket(currentLocation)) {
@@ -137,6 +167,11 @@ function runAcCommands (commands) {
     } else {
         var domainPresent = options.domain || "";
         goToMany(domainPresent, options.paths);
+    }
+
+    if (!options.entered)
+    {
+        webParser.parse(["-com", commands[0]]);
     }
 }
 

--- a/brocli/helpers.js
+++ b/brocli/helpers.js
@@ -87,3 +87,35 @@ function navCurrentDomain (relativePath) {
     }); 
 }
 
+/*
+* Pretty Print XML
+* Credit: https://gist.github.com/sente/1083506/d2834134cd070dbcc08bf42ee27dabb746a1c54d
+*/
+function formatXml(xml) {
+    var formatted = '';
+    var reg = /(>)(<)(\/*)/g;
+    xml = xml.replace(reg, '$1\r\n$2$3');
+    var pad = 0;
+    jQuery.each(xml.split('\r\n'), function(index, node) {
+        var indent = 0;
+        if (node.match( /.+<\/\w[^>]*>$/ )) {
+            indent = 0;
+        } else if (node.match( /^<\/\w/ )) {
+            if (pad != 0) {
+                pad -= 1;
+            }
+        } else if (node.match( /^<\w[^>]*[^\/]>.*$/ )) {
+            indent = 1;
+        } else {
+            indent = 0;
+        }
+        var padding = '';
+        for (var i = 0; i < pad; i++) {
+            padding += '  ';
+        }
+        formatted += padding + node + '\r\n';
+        pad += indent;
+    });
+    return formatted;
+}
+

--- a/brocli/helpers.js
+++ b/brocli/helpers.js
@@ -65,9 +65,16 @@ function goTo (newUrl, newTab) {
 function goToMany(domain, paths) {
     paths.forEach(function(path){
         var url = domain + path;
-        goTo(url, options.newTab);
-        options.newTab = true;
+        if (path.indexOf('/Store/Adminundefined') == -1)
+        {
+            goTo(url, options.newTab);
+            options.newTab = true;
+        }
+        else {
+            console.log("Brocli: Invalid Command Entered. Cannot go to " + path);
+        }
     });
+    resetOptions();
 }
 
 function navCurrentDomain (relativePath) {

--- a/brocli/helpers.js
+++ b/brocli/helpers.js
@@ -2,6 +2,7 @@
  * @fileOverview helpers
  */
 
+
 function getJson (url, callback) {
     var request = new XMLHttpRequest();
     request.open('GET', url, true);
@@ -89,33 +90,39 @@ function navCurrentDomain (relativePath) {
 
 /*
 * Pretty Print XML
-* Credit: https://gist.github.com/sente/1083506/d2834134cd070dbcc08bf42ee27dabb746a1c54d
+* <foo><bar><baz>blahblah</baz><baz>tralala</baz></bar></foo>
 */
 function formatXml(xml) {
     var formatted = '';
     var reg = /(>)(<)(\/*)/g;
-    xml = xml.replace(reg, '$1\r\n$2$3');
+    xml = xml.toString().replace(reg, '$1\r\n$2$3');
     var pad = 0;
-    jQuery.each(xml.split('\r\n'), function(index, node) {
-        var indent = 0;
-        if (node.match( /.+<\/\w[^>]*>$/ )) {
-            indent = 0;
-        } else if (node.match( /^<\/\w/ )) {
-            if (pad != 0) {
-                pad -= 1;
-            }
-        } else if (node.match( /^<\w[^>]*[^\/]>.*$/ )) {
-            indent = 1;
-        } else {
-            indent = 0;
+    var nodes = xml.split('\r\n');
+    for(var n in nodes) {
+      if (typeof nodes[n] != "string")
+        continue;
+      var node = nodes[n];
+      var indent = 0;
+      if (node.match(/.+<\/\w[^>]*>$/)) {
+        indent = 0;
+      } else if (node.match(/^<\/\w/)) {
+        if (pad !== 0) {
+          pad -= 1;
         }
-        var padding = '';
-        for (var i = 0; i < pad; i++) {
-            padding += '  ';
-        }
-        formatted += padding + node + '\r\n';
-        pad += indent;
-    });
-    return formatted;
-}
+      } else if (node.match(/^<\w[^>]*[^\/]>.*$/)) {
+        indent = 1;
+      } else {
+        indent = 0;
+      }
+    
+      var padding = '';
+      for (var i = 0; i < pad; i++) {
+        padding += '  ';
+      }
+    
+      formatted += padding + node + '\r\n';
+      pad += indent;
+    }
+    return formatted.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/ /g, '&nbsp;');
+  }
 

--- a/brocli/manifest.json
+++ b/brocli/manifest.json
@@ -59,6 +59,8 @@
   "permissions": [
     "tabs",
     "activeTab",
+    "bookmarks",
+    "storage",
     "webNavigation"
   ],
   "optional_permissions": ["activeTab"]

--- a/brocli/output.html
+++ b/brocli/output.html
@@ -1,0 +1,16 @@
+
+<style>
+    textarea {
+        height: 97%;
+        width: 100%;
+    }
+</style>
+
+<div>
+    <textarea id="terminal"></textarea>
+<br>
+<a href="#" id="copy">Copy to Clipboard</a>
+</div>
+
+<script src="/output.js"></script>
+

--- a/brocli/output.js
+++ b/brocli/output.js
@@ -1,0 +1,27 @@
+
+ function clip(id) {
+    var copyText = document.getElementById(id);
+    copyText.select();
+    document.execCommand("copy");
+}
+
+function load() {
+    chrome.storage.local.get('output', function (items) {
+        var terminal = document.getElementById("terminal");
+        terminal.innerHTML = items.output;
+    });
+}
+
+var copyLink = document.getElementById("copy");
+
+copyLink.onclick = function(){clip("terminal")};
+
+
+load();
+
+
+
+
+
+
+


### PR DESCRIPTION
When an ac command executed and the value caused buildAcUrl to return indefined, the undefined URL would be added to the option.paths. Meaning, these could build up if commands are entered incorrectly several times. So, no longer adding to options.paths if undefined in the URL. Clearing the options more and more accurately setting the currentLocation (was not always being set when switching tabs). 

Adds pretty print command for xml (should work for HTML as well) that displays the result in a new page called output.html. Also adds URL encoding command that does the same thing. Also adds ability to execute bookmarks simply by typing their exact name into brocli and hitting enter -- this is in beta and very basic at the moment; plan to improve on it. 