### PR TITLE
Fix url encode undefined results

### DIFF
--- a/brocli/commands.js
+++ b/brocli/commands.js
@@ -69,6 +69,16 @@ webParser.on('new-tab', function (name) {
     options.newTab = true;
 });
 
+webParser.on(0, function (value) {
+    chrome.bookmarks.search(value, function(results){
+        console.log(results);
+        results.forEach(function(res){
+            if (res.title == value)
+                goTo(res.url);         
+        });
+    });
+});
+
 webParser.on('*', function (name) {
     options.entered = true;
 });
@@ -95,7 +105,7 @@ webParser.on('command', function (name, value) {
         console.log(results);
         results.forEach(function(res){
             if (res.title == value)
-                window.open(res.url);         
+                goTo(res.url);      
         });
     });
 });
@@ -167,11 +177,6 @@ function runAcCommands (commands) {
     } else {
         var domainPresent = options.domain || "";
         goToMany(domainPresent, options.paths);
-    }
-
-    if (!options.entered)
-    {
-        webParser.parse(["-com", commands[0]]);
     }
 }
 

--- a/brocli/helpers.js
+++ b/brocli/helpers.js
@@ -35,10 +35,21 @@ function urlOrigin (url) {
     }
 }
 
+function isBookmarklet (str) {
+    return str.toLowerCase().split("javascript:").length > 1;
+}
+
 function creatTab (url) {
-    chrome.tabs.create({
-        'url': url
-    })
+    if (isBookmarklet(url))
+    {
+        chrome.tabs.create({'url': url}, function(tab) {
+            chrome.tabs.executeScript(tab.id, {code: url.toLowerCase().split("javascript:")[1]});
+        });
+    }
+    else
+    {
+        chrome.tabs.create({'url': url});
+    }
 }
 
 function isUrl (string) {
@@ -58,7 +69,14 @@ function goTo (newUrl, newTab) {
         if (newTab) {
             creatTab(newUrl);
         } else {
-            chrome.tabs.update(tab.id, {url: newUrl});
+            if (isBookmarklet(newUrl))
+            {
+                chrome.tabs.executeScript(tab.id, {code: newUrl.toLowerCase().split("javascript:")[1]});
+            }
+            else {
+                chrome.tabs.update(tab.id, {url: newUrl});
+            }
+
         }
     }); 
 }


### PR DESCRIPTION
Had to implement the "command" command that executed or navigates to a bookmark or bookmarklet because it was breaking the url encode command, resulting in undefined results. 